### PR TITLE
feat(core): support always get the output from the source stack

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -38,7 +38,6 @@ const project = new AwsCdkConstructLibrary({
     '@aws-cdk/aws-iam',
     '@aws-cdk/aws-lambda',
     '@aws-cdk/aws-logs',
-    '@aws-cdk/aws-sns',
     '@aws-cdk/custom-resources',
   ],
 

--- a/API.md
+++ b/API.md
@@ -35,6 +35,7 @@ new StackOutputs(scope: Construct, id: string, props: StackOutputsProps)
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[StackOutputsProps](#cdk-remote-stack-stackoutputsprops)</code>)  *No description*
   * **stack** (<code>[Stack](#aws-cdk-core-stack)</code>)  The remote CDK stack to get the outputs from. 
+  * **alwaysUpdate** (<code>boolean</code>)  Indicate whether always update the custom resource to get the new stack output. __*Default*__: true
 
 
 
@@ -73,6 +74,7 @@ Properties of the StackOutputs.
 Name | Type | Description 
 -----|------|-------------
 **stack** | <code>[Stack](#aws-cdk-core-stack)</code> | The remote CDK stack to get the outputs from.
+**alwaysUpdate**? | <code>boolean</code> | Indicate whether always update the custom resource to get the new stack output.<br/>__*Default*__: true
 
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Let's say we have two cross-region CDK stacks in the same cdk app:
 ```ts
 import { StackOutputs } from 'cdk-remote-stack';
 import * as cdk from '@aws-cdk/core';
-import * as sns from '@aws-cdk/aws-sns';
 
 const app = new cdk.App();
 
@@ -41,9 +40,7 @@ const envUS = {
 // first stack in JP
 const stackJP = new cdk.Stack(app, 'demo-stack-jp', { env: envJP })
 
-const topic = new sns.Topic(stackJP, 'Topic');
-
-new cdk.CfnOutput(stackJP, 'TopicName', { value: topic.topicName })
+new cdk.CfnOutput(stackJP, 'TopicName', { value: 'foo' })
 
 // second stack in US
 const stackUS = new cdk.Stack(app, 'demo-stack-us', { env: envUS })
@@ -58,4 +55,18 @@ const remoteOutputValue = outputs.getAttString('TopicName')
 
 // the value should be exactly the same with the output value of `TopicName`
 new cdk.CfnOutput(stackUS, 'RemoteTopicName', { value: remoteOutputValue })
+```
+
+
+## always get the latest stack output
+
+By default, the `StackOutputs` construct will always try to get the latest output from the source stack, you may opt out by setting `alwaysUpdate` to `false` to turn this feature off.
+
+For example:
+
+```ts
+const outputs = new StackOutputs(stackUS, 'Outputs', { 
+  stack: stackJP,
+  alwaysUpdate: false,
+})
 ```

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@aws-cdk/aws-iam": "^1.62.0",
     "@aws-cdk/aws-lambda": "^1.62.0",
     "@aws-cdk/aws-logs": "^1.62.0",
-    "@aws-cdk/aws-sns": "^1.62.0",
     "@aws-cdk/core": "^1.62.0",
     "@aws-cdk/custom-resources": "^1.62.0",
     "constructs": "^3.2.0"
@@ -65,7 +64,6 @@
     "@aws-cdk/aws-iam": "^1.62.0",
     "@aws-cdk/aws-lambda": "^1.62.0",
     "@aws-cdk/aws-logs": "^1.62.0",
-    "@aws-cdk/aws-sns": "^1.62.0",
     "@aws-cdk/core": "^1.62.0",
     "@aws-cdk/custom-resources": "^1.62.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import * as cdk from '@aws-cdk/core';
+import * as path from 'path';
 import { PolicyStatement } from '@aws-cdk/aws-iam';
 import * as lambda from '@aws-cdk/aws-lambda';
 import * as logs from '@aws-cdk/aws-logs';
+import * as cdk from '@aws-cdk/core';
 import * as cr from '@aws-cdk/custom-resources';
-import * as path from 'path';
 
 /**
  * Properties of the StackOutputs
@@ -13,6 +13,11 @@ export interface StackOutputsProps {
    * The remote CDK stack to get the outputs from.
    */
   readonly stack: cdk.Stack;
+  /**
+   * Indicate whether always update the custom resource to get the new stack output
+   * @default true
+   */
+  readonly alwaysUpdate?: boolean;
 }
 
 /**
@@ -25,7 +30,7 @@ export class StackOutputs extends cdk.Construct {
   readonly outputs: cdk.CustomResource;
 
   constructor(scope: cdk.Construct, id: string, props: StackOutputsProps) {
-    super(scope, id)
+    super(scope, id);
 
     const onEvent = new lambda.Function(this, 'MyHandler', {
       runtime: lambda.Runtime.PYTHON_3_8,
@@ -48,6 +53,7 @@ export class StackOutputs extends cdk.Construct {
       properties: {
         stackName: props.stack.stackName,
         regionName: cdk.Stack.of(props.stack).region,
+        randomString: props.alwaysUpdate == false ? undefined : randomString(),
       },
     });
   }
@@ -57,7 +63,13 @@ export class StackOutputs extends cdk.Construct {
    * @param key output key
    */
   public getAttString(key: string) {
-    return this.outputs.getAttString(key)
+    return this.outputs.getAttString(key);
   }
 
+}
+
+
+function randomString() {
+  // Crazy
+  return Math.random().toString(36).replace(/[^a-z0-9]+/g, '');
 }

--- a/src/integ.default.ts
+++ b/src/integ.default.ts
@@ -1,11 +1,10 @@
-import { StackOutputs } from './';
 import * as cdk from '@aws-cdk/core';
-import * as sns from '@aws-cdk/aws-sns';
+import { StackOutputs } from './';
 
 export class IntegTesting {
   readonly stack: cdk.Stack[];
 
-  constructor(){
+  constructor() {
 
     const app = new cdk.App();
 
@@ -20,27 +19,28 @@ export class IntegTesting {
     };
 
     // first stack in JP
-    const stackJP = new cdk.Stack(app, 'demo-stack-jp', { env: envJP })
+    const stackJP = new cdk.Stack(app, 'demo-stack-jp', { env: envJP });
 
-    const topic = new sns.Topic(stackJP, 'Topic');
-
-    new cdk.CfnOutput(stackJP, 'TopicName', { value: topic.topicName })
+    new cdk.CfnOutput(stackJP, 'TopicName', { value: 'foo' });
 
     // second stack in US
-    const stackUS = new cdk.Stack(app, 'demo-stack-us', { env: envUS })
+    const stackUS = new cdk.Stack(app, 'demo-stack-us', { env: envUS });
 
     // ensure the dependency
-    stackUS.addDependency(stackJP)
+    stackUS.addDependency(stackJP);
 
     // get the stackJP stack outputs from stackUS
-    const outputs = new StackOutputs(stackUS, 'Outputs', { stack: stackJP })
+    const outputs = new StackOutputs(stackUS, 'Outputs', {
+      stack: stackJP,
+      alwaysUpdate: false,
+    });
 
-    const remoteOutputValue = outputs.getAttString('TopicName')
+    const remoteOutputValue = outputs.getAttString('TopicName');
 
     // the value should be exactly the same with the output value of `TopicName`
-    new cdk.CfnOutput(stackUS, 'RemoteTopicName', { value: remoteOutputValue })
+    new cdk.CfnOutput(stackUS, 'RemoteTopicName', { value: remoteOutputValue });
 
-    this.stack = [ stackJP, stackUS ]
+    this.stack = [stackJP, stackUS];
   }
 }
 

--- a/test/__snapshots__/integ.main.test.ts.snap
+++ b/test/__snapshots__/integ.main.test.ts.snap
@@ -4,17 +4,7 @@ exports[`integ snapshot validation 1`] = `
 Object {
   "Outputs": Object {
     "TopicName": Object {
-      "Value": Object {
-        "Fn::GetAtt": Array [
-          "TopicBFC7AF6E",
-          "TopicName",
-        ],
-      },
-    },
-  },
-  "Resources": Object {
-    "TopicBFC7AF6E": Object {
-      "Type": "AWS::SNS::Topic",
+      "Value": "foo",
     },
   },
 }

--- a/test/integ.main.test.ts
+++ b/test/integ.main.test.ts
@@ -1,10 +1,10 @@
 import '@aws-cdk/assert/jest';
-import { IntegTesting } from '../src/integ.default';
 import { SynthUtils } from '@aws-cdk/assert';
+import { IntegTesting } from '../src/integ.default';
 
 test('integ snapshot validation', () => {
   const integ = new IntegTesting();
   integ.stack.forEach(stack => {
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
-})
+});

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,6 +1,6 @@
-import { StackOutputs } from '../src';
-import * as cdk from '@aws-cdk/core';
 import * as sns from '@aws-cdk/aws-sns';
+import * as cdk from '@aws-cdk/core';
+import { StackOutputs } from '../src';
 import '@aws-cdk/assert/jest';
 
 test('create the ServerlessAPI', () => {
@@ -17,22 +17,22 @@ test('create the ServerlessAPI', () => {
   };
 
   // first stack in JP
-  const stackJP = new cdk.Stack(app, 'demo-stack-jp', { env: envJP })
+  const stackJP = new cdk.Stack(app, 'demo-stack-jp', { env: envJP });
 
   const topic = new sns.Topic(stackJP, 'Topic');
 
-  new cdk.CfnOutput(stackJP, 'TopicName', { value: topic.topicName })
+  new cdk.CfnOutput(stackJP, 'TopicName', { value: topic.topicName });
 
   // second stack in US
-  const stackUS = new cdk.Stack(app, 'demo-stack-us', { env: envUS })
+  const stackUS = new cdk.Stack(app, 'demo-stack-us', { env: envUS });
 
   // get the stackJP stack outputs from stackUS
-  const outputs = new StackOutputs(stackUS, 'Outputs', { stack: stackJP })
+  const outputs = new StackOutputs(stackUS, 'Outputs', { stack: stackJP });
 
-  const remoteOutputValue = outputs.getAttString('TopicName')
+  const remoteOutputValue = outputs.getAttString('TopicName');
 
   // the value should be exactly the same with the output value of `TopicName`
-  new cdk.CfnOutput(stackUS, 'RemoteTopicName', { value: remoteOutputValue })
+  new cdk.CfnOutput(stackUS, 'RemoteTopicName', { value: remoteOutputValue });
 
   expect(stackUS).toHaveResource('AWS::CloudFormation::CustomResource', {
     ServiceToken: {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,4 +1,3 @@
-import * as sns from '@aws-cdk/aws-sns';
 import * as cdk from '@aws-cdk/core';
 import { StackOutputs } from '../src';
 import '@aws-cdk/assert/jest';
@@ -19,9 +18,7 @@ test('create the ServerlessAPI', () => {
   // first stack in JP
   const stackJP = new cdk.Stack(app, 'demo-stack-jp', { env: envJP });
 
-  const topic = new sns.Topic(stackJP, 'Topic');
-
-  new cdk.CfnOutput(stackJP, 'TopicName', { value: topic.topicName });
+  new cdk.CfnOutput(stackJP, 'TopicName', { value: 'foo' });
 
   // second stack in US
   const stackUS = new cdk.Stack(app, 'demo-stack-us', { env: envUS });

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,7 +185,7 @@
     "@aws-cdk/core" "1.73.0"
     constructs "^3.2.0"
 
-"@aws-cdk/aws-sns@1.73.0", "@aws-cdk/aws-sns@^1.62.0":
+"@aws-cdk/aws-sns@1.73.0":
   version "1.73.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.73.0.tgz#c755901d231805389845be264d69660aec2fe941"
   integrity sha512-Ovo39L+u2zozgd2NQZp67BEfmYoIanfaE00RCAXp1pSm3IGt3OjfXbWuaiyLwMUUex866+MNkQ9Hr4WO/0mRsw==
@@ -1639,9 +1639,9 @@ concat-stream@^2.0.0:
     typedarray "^0.0.6"
 
 constructs@^3.2.0:
-  version "3.2.29"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.2.29.tgz#0e1129709d90f6b3fa8100f892cd9074a86428c0"
-  integrity sha512-bNI0dfmFOs2+S8vfZE0febWVRaFSUFtPNT8CJNBYW3DUEK73vf6n66ZtkROei3W0gihYiEbQD2pbxMP3+PpbcQ==
+  version "3.2.30"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.2.30.tgz#950a1e38d7193791fea55f847f87013959748475"
+  integrity sha512-tzWUxXc9UjPbw1+c0s6gFL0ae4gPgsKck59xfkjOnyezPNcG2myB/xh9wGD51kbn+GInW0vMgW0QWOn0WhKa4g==
 
 contains-path@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
- add `alwaysUpdate` property for `StackOutput` to force get the output from the source stack.

Fixes #118 