### PR TITLE
chore: Update description of the construct

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk-remote-stack",
-  "description": "Get outputs and parameters from remote CDK stacks",
+  "description": "Get outputs from cross-region AWS CloudFormation stacks",
   "repository": {
     "type": "git",
     "url": "https://github.com/pahud/cdk-remote-stack.git"


### PR DESCRIPTION
AWS CDK describes AWS CloudFormation stacks using a template. After the template is deployed, the references are between CloudFormation stacks.

Fixes #