### PR TITLE
chore: replace the build badge with the release one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![npm version](https://badge.fury.io/js/cdk-remote-stack.svg)](https://badge.fury.io/js/cdk-remote-stack)
 [![PyPI version](https://badge.fury.io/py/cdk-remote-stack.svg)](https://badge.fury.io/py/cdk-remote-stack)
-[![Build](https://github.com/pahud/cdk-remote-stack/actions/workflows/build.yml/badge.svg)](https://github.com/pahud/cdk-remote-stack/actions/workflows/build.yml)
+[![release](https://github.com/pahud/cdk-remote-stack/actions/workflows/release.yml/badge.svg)](https://github.com/pahud/cdk-remote-stack/actions/workflows/release.yml)
 
 # cdk-remote-stack
 


### PR DESCRIPTION
Use the `release` badge in the README.


<a href="https://gitpod.io/#https://github.com/pahud/cdk-remote-stack/pull/440"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

