### PR TITLE
chore: update cdkVersion to 2.0.0

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.1.0",
+      "version": "2.0.0",
       "type": "build"
     },
     {
@@ -99,7 +99,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.1.0",
+      "version": "^2.0.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -29,7 +29,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
   releaseBranches: {
     cdkv1: { npmDistTag: 'cdkv1', majorVersion: 1 },
   },
-  workflowNodeVersion: '^14.17.0',
   depsUpgradeOptions: {
     ignoreProjen: false,
     workflowOptions: {
@@ -46,7 +45,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     twitter: 'pahudnet',
     announce: false,
   },
-  cdkVersion: '2.1.0',
+  cdkVersion: '2.0.0',
   workflowNodeVersion: '14.17.0',
   python: {
     distName: 'cdk-remote-stack',

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^14.17.0",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.1.0",
+    "aws-cdk-lib": "2.0.0",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
@@ -59,7 +59,7 @@
     "typescript": "^4.5.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.1.0",
+    "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.5"
   },
   "bundledDependencies": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1152,10 +1152,10 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.1.0.tgz#2497484cfd4e2eeaba99b070bbfa54486d52ae34"
-  integrity sha512-W607G3aSrWpawpcqzIuUYKlU+grfvkbszyqikyVYqJgMHFCCQXq0S1ynPMzfQ49CwjlwZsu4LIsPM+dNR+Yj6g==
+aws-cdk-lib@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.0.0.tgz#da7cf476363771f5ce4eb2aa73388b91db50553e"
+  integrity sha512-ETom3THcblmS3GSoS6rb2AGy7HZpcpoHvwNlxeVIVbmGOiKrrqjvECK2uOJtNboV/vDTHHjx/s/1SwptLo9dlg==
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"


### PR DESCRIPTION
- `cdkVersion` should be 2.0.0 in `.projenrc.js`
- remove duplicate `workflowNodeVersion`

Fixes #459 

<a href="https://gitpod.io/#https://github.com/pahud/cdk-remote-stack/pull/464"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

