### PR TITLE
feat: support for parameters without slashes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,10 @@ export class RemoteParameters extends Construct {
     });
 
     onEvent.addToRolePolicy(new iam.PolicyStatement({
-      actions: ['ssm:GetParametersByPath'],
+      actions: [
+        'ssm:GetParameter',
+        'ssm:GetParametersByPath',
+      ],
       resources: ['*'],
     }));
 

--- a/test/__snapshots__/integ.main.test.ts.snap
+++ b/test/__snapshots__/integ.main.test.ts.snap
@@ -152,7 +152,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-west-2",
           },
-          "S3Key": "3803df2f6849acf50bb6577ee095a669940670e799f70a2be34893a399777bc3.zip",
+          "S3Key": "4b6f72776eeaebb01b3d2d7f24abdc1eecb6b1de9471dd677a13066705d50575.zip",
         },
         "Handler": "remote-outputs.on_event",
         "Role": Object {


### PR DESCRIPTION
Currently, parameters structured with slashes, such as `/some/parameter`, can be successfully retrieved using the get_parameters_by_path API. However, when attempting to retrieve parameters that are not structured with slashes, such as `some-parameter`, the following error occurs when using get_parameters_by_path, leading to failure.

```
Received response status [FAILED] from custom resource. Message returned: Error: An error occurred (ValidationException) when calling the GetParametersByPath operation: The parameter doesn'
t meet the parameter name requirements. The parameter name must begin with a forward slash "/". It can't be prefixed with \"aws\" or \"ssm\" (case-insensitive). It must use only letters, nu
mbers, or the following symbols: . (period), - (hyphen), _ (underscore). Special characters are not allowed. All sub-paths, if specified, must use the forward slash symbol "/". Valid exampl
e: /get/parameters2-/by1./path0_.
```

This PR supports for handling non-hierarchical parameters (those without slashes) by incorporating the get_parameter API in addition to the existing get_parameters_by_path API. This allows retrieval of both hierarchical and non-hierarchical parameters.