### PR TITLE
chore: bump lambda runtime to python 3.13 (EOL 3.9) #606

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export class RemoteOutputs extends Construct {
     super(scope, id);
 
     const onEvent = new lambda.Function(this, 'MyHandler', {
-      runtime: lambda.Runtime.PYTHON_3_9,
+      runtime: lambda.Runtime.PYTHON_3_13,
       code: lambda.Code.fromAsset(path.join(__dirname, '../custom-resource-handler')),
       handler: 'remote-outputs.on_event',
       timeout: props.timeout,
@@ -122,7 +122,7 @@ export class RemoteParameters extends Construct {
     super(scope, id);
 
     const onEvent = new lambda.Function(this, 'MyHandler', {
-      runtime: lambda.Runtime.PYTHON_3_9,
+      runtime: lambda.Runtime.PYTHON_3_13,
       code: lambda.Code.fromAsset(path.join(__dirname, '../custom-resource-handler')),
       handler: 'remote-parameters.on_event',
       timeout: props.timeout,


### PR DESCRIPTION
With Python 3.9 reaching EOL in October of this year (2025), I’ve raised this pull request to bump Lambda’s runtime to 3.13

※ According to the docs Boto3 is compatible with Python 3.9 and up:
https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#install-or-update-python
I’ve also raised the following PR to bump the runtime to Python 3.10,
in case you feel that this would be a safer move :)
https://github.com/pahud/cdk-remote-stack/pull/607 
If you choose to merge this PR, please feel free to close the other!